### PR TITLE
Resolve `strlen()` warning

### DIFF
--- a/classes/fields/text.php
+++ b/classes/fields/text.php
@@ -165,7 +165,7 @@ class PodsField_Text extends PodsField {
 		if ( is_array( $check ) ) {
 			$errors = $check;
 		} else {
-			if ( 0 < strlen( $value ) && '' === $check ) {
+			if ( 0 < strlen( (string) $value ) && '' === $check ) {
 				if ( $this->is_required( $options ) ) {
 					$errors[] = __( 'This field is required.', 'pods' );
 				}


### PR DESCRIPTION
Resolve `Warning: strlen() expects parameter 1 to be string, array given in wp-content/plugins/pods/classes/fields/text.php on line 168`